### PR TITLE
Omitted superfluous parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ Note: TypeScript and Vue.js must be installed as well.
 ### Example Component
 ```typescript
 import Vue = require('vue')
-import * as vts from 'vue-typescript-component'
+import { Component, prop, watch, injected } from 'vue-typescript-component'
 // see note about import *.vue files below
 import * as ChildComponent from './child.vue'
 
-@vts.component({components: {ChildComponent}})
+@Component({components: {ChildComponent}})
 export default class Example extends Vue {
 	// this will be 'data'
 	aString = 'abc'
 	aNumber = 123
 
 	// props with initializer -> sets default value and type
-	@vts.prop() aStringPropWithValue = 'abc'
-	@vts.prop() aNumberPropWithValue = 123
+	@prop aStringPropWithValue = 'abc'
+	@prop aNumberPropWithValue = 123
 
 	// props without initializer -> sets required=true
-	@vts.prop() aStringProp: string
-	@vts.prop() aNumberProp: number
+	@prop aStringProp: string
+	@prop aNumberProp: number
 
 	// computed props
 	get aComputedString(): string { return this.aString }
@@ -48,11 +48,11 @@ export default class Example extends Vue {
 	created() { /* ... */ }
 
 	// watches
-	@vts.watch('aString') aStringWatch(val: string, oldVal: string) { /* ... */ }
+	@watch('aString') aStringWatch(val: string, oldVal: string) { /* ... */ }
 
 	// mark as injected, e.g., by a plugin, and do not use in data()
 	// names starting with '$' or '_' are always ignored
-	@vts.injected() errors: any
+	@injected errors: any
 }
 ```
 

--- a/src/vue-typescript-component.ts
+++ b/src/vue-typescript-component.ts
@@ -44,19 +44,28 @@ function getOrCreateComponent(target: any): VueTypescriptComponentData {
 /** Use field as property
  * If field is initialized, sets default value and type. Otherwise mark as required
  */
-export function prop(options: Vue.PropOptions = {}) {
-	return (target: any, member: string) => {
-		getOrCreateComponent(target).props[member] = options
+export type PropDecorator = (target: any, member: string) => void
+export function prop(target: any, member: string): void
+export function prop(options: Vue.PropOptions): PropDecorator
+export function prop(options: Vue.PropOptions | any, member?: string): PropDecorator | void {
+	function makePropDecorator(options: Vue.PropOptions = {}): PropDecorator {
+		return (target: any, member: string) => {
+			getOrCreateComponent(target).props[member] = options
+		}
+	}
+
+	if (member) {
+		return makePropDecorator()(options, member!)
+	} else {
+		return makePropDecorator(options)
 	}
 }
 
 /** Ignore field
  * Use on injected fields to make sure they do not appear in data()
  */
-export function injected() {
-	return (target: any, member: string) => {
-		getOrCreateComponent(target).injected[member] = {}
-	}
+export function injected(target: any, member: string): void {
+	getOrCreateComponent(target).injected[member] = {}
 }
 
 /** Use method(val, oldVal) to watch expression
@@ -82,6 +91,10 @@ export interface NoArgumentConstructable {
 	vueComponentOptions?: Vue.ComponentOptions<Vue>
 }
 
+function isNoArgumentConstructable(arg: any): arg is NoArgumentConstructable {
+   return arg instanceof Function;
+}
+
 const lifecycleHooks = ['beforeCreate', 'created', 'beforeMount', 'mounted',
 		'beforeUpdate', 'updated', 'activated', 'deactivated',
 		'beforeDestroy', 'destroyed',
@@ -91,85 +104,101 @@ const lifecycleHooks = ['beforeCreate', 'created', 'beforeMount', 'mounted',
 /** Create property constructor.vueComponentOptions based on method/field annotations
  *  If provided, use options as the base value (.data is always overridden)
  */
-export function component(options: Vue.ComponentOptions<Vue> = {}) {
-	return (cls: NoArgumentConstructable) => {
-		const d = getOrCreateComponent(cls.prototype)
-		const superOptions: Vue.ComponentOptions<Vue> = <Vue.ComponentOptions<Vue>>cls.vueComponentOptions || {}
-		const obj = new cls()
-		cls.vueComponentOptions = options
-		options.name = options.name || (<any>cls).name
-		options.methods = objAssign({}, superOptions.methods, options.methods)
-		options.computed = objAssign({}, superOptions.computed, options.computed)
-		options.watch = objAssign({}, superOptions.watch, options.watch)
-		options.props = objAssign({}, superOptions.props, options.props)
-		// to get rid of Index signature of object type implicitly has an 'any' type.
-		const props = <{ [key: string]: Vue.PropOptions }>options.props
-		options.data = () => {
-			const newData = new cls()
-			const r: any = {}
-			for (let n of Object.getOwnPropertyNames(newData)) {
-				if (!props[n] && n[0] !== '_' && n[0] !== '$' && !d.injected[n]) {
-					r[n] = newData[n]
+export type ComponentDecorator = (cls: NoArgumentConstructable) => void
+export function component(cls: NoArgumentConstructable): void
+export function component(options: Vue.ComponentOptions<Vue>): ComponentDecorator
+export function component(options: Vue.ComponentOptions<Vue> | NoArgumentConstructable): ComponentDecorator | void {
+	function makeComponent(options: Vue.ComponentOptions<Vue> = {}): ComponentDecorator {
+		return (cls: NoArgumentConstructable) => {
+			const d = getOrCreateComponent(cls.prototype)
+			const superOptions: Vue.ComponentOptions<Vue> = <Vue.ComponentOptions<Vue>>cls.vueComponentOptions || {}
+			const obj = new cls()
+			cls.vueComponentOptions = options
+			options.name = options.name || (<any>cls).name
+			options.methods = objAssign({}, superOptions.methods, options.methods)
+			options.computed = objAssign({}, superOptions.computed, options.computed)
+			options.watch = objAssign({}, superOptions.watch, options.watch)
+			options.props = objAssign({}, superOptions.props, options.props)
+			// to get rid of Index signature of object type implicitly has an 'any' type.
+			const props = <{ [key: string]: Vue.PropOptions }>options.props
+			options.data = () => {
+				const newData = new cls()
+				const r: any = {}
+				for (let n of Object.getOwnPropertyNames(newData)) {
+					if (!props[n] && n[0] !== '_' && n[0] !== '$' && !d.injected[n]) {
+						r[n] = newData[n]
+					}
 				}
+				return r
 			}
-			return r
-		}
 
-		for (let n of Object.getOwnPropertyNames(d.props)) {
-			props[n] = d.props[n]
-		}
-		// create data; add default values and types to props with initialisers
-		for (let n of Object.getOwnPropertyNames(obj)) {
-			if (props[n]) {
-				if (typeof obj[n] === 'object') {
-					props[n].default = () => { return new cls()[n] }
-				} else {
-					props[n].default = obj[n]
-				}
-				if (props[n].type === undefined) {
-					try {
-						props[n].type = Object.getPrototypeOf(obj[n]).constructor
-					} catch (error) {
-						// IE throws a TypeError exception if the parameter isn't an object
-						props[n].type = obj[n].__proto__ ? obj[n].__proto__.constructor : obj[n].constructor
+			for (let n of Object.getOwnPropertyNames(d.props)) {
+				props[n] = d.props[n]
+			}
+			// create data; add default values and types to props with initialisers
+			for (let n of Object.getOwnPropertyNames(obj)) {
+				if (props[n]) {
+					if (typeof obj[n] === 'object') {
+						props[n].default = () => { return new cls()[n] }
+					} else {
+						props[n].default = obj[n]
+					}
+					if (props[n].type === undefined) {
+						try {
+							props[n].type = Object.getPrototypeOf(obj[n]).constructor
+						} catch (error) {
+							// IE throws a TypeError exception if the parameter isn't an object
+							props[n].type = obj[n].__proto__ ? obj[n].__proto__.constructor : obj[n].constructor
+						}
 					}
 				}
 			}
-		}
-		// set props without default value to required
-		for (let n in props) {
-			if (props[n].required === undefined && props[n].default === undefined) {
-				props[n].required = true
-			}
-		}
-		// methods
-		for (let n of Object.getOwnPropertyNames(cls.prototype)) {
-			if (n === 'constructor' || n === '$$vueTypescriptComponentData') {
-				continue
-			}
-			const pd = Object.getOwnPropertyDescriptor(cls.prototype, n)
-			if (pd.set) {
-				options.computed![n] = { set: pd.set, get: pd.get }
-			} else if (pd.get) {
-				options.computed![n] = pd.get
-			} else if (lifecycleHooks.indexOf(n) !== -1) {
-				(<any>options)[n] = pd.value
-			} else {
-				options.methods![n] = pd.value
-			}
-		}
-		// watch
-		for (let n of Object.getOwnPropertyNames(d.watch)) {
-			if (!options.methods![n]) {
-				throw '@watch must decorate a method: ' + cls.name + '.' + n
-			}
-			for (let o of d.watch[n]) {
-				if (options.watch![o.expression] && superOptions.watch![o.expression] !== options.watch![o.expression]) {
-					throw 'duplicate watch expression: ' + cls.name + '.' + o.expression
+			// set props without default value to required
+			for (let n in props) {
+				if (props[n].required === undefined && props[n].default === undefined) {
+					props[n].required = true
 				}
-				o.options.handler = obj[n]
-				options.watch![o.expression] = o.options
+			}
+			// methods
+			for (let n of Object.getOwnPropertyNames(cls.prototype)) {
+				if (n === 'constructor' || n === '$$vueTypescriptComponentData') {
+					continue
+				}
+				const pd = Object.getOwnPropertyDescriptor(cls.prototype, n)
+				if (pd.set) {
+					options.computed![n] = { set: pd.set, get: pd.get }
+				} else if (pd.get) {
+					options.computed![n] = pd.get
+				} else if (lifecycleHooks.indexOf(n) !== -1) {
+					(<any>options)[n] = pd.value
+				} else {
+					options.methods![n] = pd.value
+				}
+			}
+			// watch
+			for (let n of Object.getOwnPropertyNames(d.watch)) {
+				if (!options.methods![n]) {
+					throw '@watch must decorate a method: ' + cls.name + '.' + n
+				}
+				for (let o of d.watch[n]) {
+					if (options.watch![o.expression] && superOptions.watch![o.expression] !== options.watch![o.expression]) {
+						throw 'duplicate watch expression: ' + cls.name + '.' + o.expression
+					}
+					o.options.handler = obj[n]
+					options.watch![o.expression] = o.options
+				}
 			}
 		}
 	}
+
+	if (isNoArgumentConstructable(options)) {
+		return makeComponent()(options)
+	} else {
+		return makeComponent(options)
+	}
 }
+
+export const Prop      = prop
+export const Watch     = watch
+export const Injected  = injected
+export const Component = component

--- a/src/vue-typescript-component.ts
+++ b/src/vue-typescript-component.ts
@@ -92,7 +92,7 @@ export interface NoArgumentConstructable {
 }
 
 function isNoArgumentConstructable(arg: any): arg is NoArgumentConstructable {
-   return arg instanceof Function;
+	return arg instanceof Function
 }
 
 const lifecycleHooks = ['beforeCreate', 'created', 'beforeMount', 'mounted',

--- a/test/all-in-one.spec.ts
+++ b/test/all-in-one.spec.ts
@@ -1,9 +1,9 @@
 /// <reference path='../node_modules/@types/jest/index.d.ts' />
 
 import Vue = require('vue')
-import * as vts from '../src/vue-typescript-component'
+import { Component, prop, watch } from '../src/vue-typescript-component'
 
-@vts.component()
+@Component
 class AllInOne extends Vue {
 	aString = 'abc'
 	aNumber = 123
@@ -11,11 +11,11 @@ class AllInOne extends Vue {
 	_thisWillBeIgnored = 345
 	$asWillThis = 345
 
-	@vts.prop() aStringPropWithValue = 'abc'
-	@vts.prop() aNumberPropWithValue = 123
+	@prop aStringPropWithValue = 'abc'
+	@prop aNumberPropWithValue = 123
 
-	@vts.prop() aStringProp: string
-	@vts.prop() aNumberProp: number
+	@prop aStringProp: string
+	@prop aNumberProp: number
 
 	get aComputedString(): string { return this.aString }
 	set aComputedString(value: string) { this.aString = value }
@@ -31,7 +31,7 @@ class AllInOne extends Vue {
 	// a lifecycle hook
 	created() { /* do nothing */ }
 
-	@vts.watch('aString') aStringWatch(val: string, oldVal: string) { /* do nothing */ }
+	@watch('aString') aStringWatch(val: string, oldVal: string) { /* do nothing */ }
 }
 
 it('creates the expected options', () => {

--- a/test/inheritance-vue.spec.ts
+++ b/test/inheritance-vue.spec.ts
@@ -6,23 +6,23 @@
 import Vue = require('vue')
 import * as vts from '../src/vue-typescript-component'
 
-@vts.component()
+@vts.component
 class Root extends Vue {
 }
 
-@vts.component()
+@vts.component
 class Empty extends Root {
 }
 
-@vts.component()
+@vts.component
 class EmptyEmpty extends Empty {
 }
 
-@vts.component()
+@vts.component
 class EmptyFull extends Empty {
 	bData = 'abc'
 
-	@vts.prop() bProp = 'abc'
+	@vts.prop bProp = 'abc'
 
 	get bComputedProp(): string { return this.bData }
 	set bComputedProp(value: string) { this.bData = value }
@@ -35,11 +35,11 @@ class EmptyFull extends Empty {
 	@vts.watch('bData') bWatch(val: string, oldVal: string) { /* do nothing */ }
 }
 
-@vts.component()
+@vts.component
 class Full extends Root {
 	aData = 'abc'
 
-	@vts.prop() aProp = 'abc'
+	@vts.prop aProp = 'abc'
 
 	get aComputedProp(): string { return this.aData }
 	set aComputedProp(value: string) { this.aData = value }
@@ -52,15 +52,15 @@ class Full extends Root {
 	@vts.watch('aData') aWatch(val: string, oldVal: string) { /* do nothing */ }
 }
 
-@vts.component()
+@vts.component
 class FullEmpty extends Full {
 }
 
-@vts.component()
+@vts.component
 class FullFull extends Full {
 	bData = 'abc'
 
-	@vts.prop() bProp = 'abc'
+	@vts.prop bProp = 'abc'
 
 	get bComputedProp(): string { return this.bData }
 	set bComputedProp(value: string) { this.bData = value }
@@ -73,12 +73,12 @@ class FullFull extends Full {
 	@vts.watch('bData') bWatch(val: string, oldVal: string) { /* do nothing */ }
 }
 
-@vts.component()
+@vts.component
 class FullOverride extends Full {
 	aData = '123'
 	bData = 'abc'
 
-	@vts.prop() aProp = '123'
+	@vts.prop aProp = '123'
 
 	get aComputedProp(): string { return this.bData }
 	set aComputedProp(value: string) { this.bData = value }

--- a/test/inheritance.spec.ts
+++ b/test/inheritance.spec.ts
@@ -2,23 +2,23 @@
 
 import * as vts from '../src/vue-typescript-component'
 
-@vts.component()
+@vts.component
 class Root {
 }
 
-@vts.component()
+@vts.component
 class Empty extends Root {
 }
 
-@vts.component()
+@vts.component
 class EmptyEmpty extends Empty {
 }
 
-@vts.component()
+@vts.component
 class EmptyFull extends Empty {
 	bData = 'abc'
 
-	@vts.prop() bProp = 'abc'
+	@vts.prop bProp = 'abc'
 
 	get bComputedProp(): string { return this.bData }
 	set bComputedProp(value: string) { this.bData = value }
@@ -31,11 +31,11 @@ class EmptyFull extends Empty {
 	@vts.watch('bData') bWatch(val: string, oldVal: string) { /* do nothing */ }
 }
 
-@vts.component()
+@vts.component
 class Full extends Root {
 	aData = 'abc'
 
-	@vts.prop() aProp = 'abc'
+	@vts.prop aProp = 'abc'
 
 	get aComputedProp(): string { return this.aData }
 	set aComputedProp(value: string) { this.aData = value }
@@ -48,15 +48,15 @@ class Full extends Root {
 	@vts.watch('aData') aWatch(val: string, oldVal: string) { /* do nothing */ }
 }
 
-@vts.component()
+@vts.component
 class FullEmpty extends Full {
 }
 
-@vts.component()
+@vts.component
 class FullFull extends Full {
 	bData = 'abc'
 
-	@vts.prop() bProp = 'abc'
+	@vts.prop bProp = 'abc'
 
 	get bComputedProp(): string { return this.bData }
 	set bComputedProp(value: string) { this.bData = value }
@@ -69,12 +69,12 @@ class FullFull extends Full {
 	@vts.watch('bData') bWatch(val: string, oldVal: string) { /* do nothing */ }
 }
 
-@vts.component()
+@vts.component
 class FullOverride extends Full {
 	aData = '123'
 	bData = 'abc'
 
-	@vts.prop() aProp = '123'
+	@vts.prop aProp = '123'
 
 	get aComputedProp(): string { return this.bData }
 	set aComputedProp(value: string) { this.bData = value }

--- a/test/injected.spec.ts
+++ b/test/injected.spec.ts
@@ -9,17 +9,17 @@ class A extends Vue {
 	abc = 1
 }
 
-@vts.component()
+@vts.component
 class B extends A {
 	b = 1
 	bc = 1
-	@vts.injected() a: number
+	@vts.injected a: number
 }
 
-@vts.component()
+@vts.component
 class C extends B {
-	@vts.injected() ab: number
-	@vts.injected() b: number
+	@vts.injected ab: number
+	@vts.injected b: number
 	c = 1
 }
 

--- a/test/lifecyle-hooks.spec.ts
+++ b/test/lifecyle-hooks.spec.ts
@@ -6,7 +6,7 @@ import * as vts from '../src/vue-typescript-component'
 // global, because data is not available in all hooks
 let history: string[] = []
 
-@vts.component()
+@vts.component
 class LifecycleHook extends Vue {
 	blub = 1
 	beforeCreate() { history.push('beforeCreate') }

--- a/test/refs.spec.ts
+++ b/test/refs.spec.ts
@@ -8,7 +8,7 @@ import * as vts from '../src/vue-typescript-component'
 
 @vts.component({template: '<div>{{val}}</div>'})
 class Child extends Vue {
-	@vts.prop() val: number
+	@vts.prop val: number
 
 	double() {
 		return this.val * 2

--- a/test/render-function.spec.ts
+++ b/test/render-function.spec.ts
@@ -3,10 +3,10 @@
 import Vue = require('vue')
 import * as vts from '../src/vue-typescript-component'
 
-@vts.component()
+@vts.component
 class RenderFunction extends Vue {
-	@vts.prop() level = 3
-	@vts.prop() text = 'a heading'
+	@vts.prop level = 3
+	@vts.prop text = 'a heading'
 
 	render(createElement: typeof Vue.prototype.$createElement) {
 		return createElement('h' + this.level, this.text)

--- a/test/some-data.spec.ts
+++ b/test/some-data.spec.ts
@@ -10,7 +10,7 @@ class Foo {
 	someObject = {aString: 'abc', aNumber: 123, aArray: [123, 'abc']}
 }
 
-@vts.component()
+@vts.component
 class JustData extends Vue {
 	someString = 'abc'
 	someNumber = 123

--- a/test/some-props.spec.ts
+++ b/test/some-props.spec.ts
@@ -48,7 +48,7 @@ it('accepts the intended props', () => new Promise((resolve, reject) => {
 			someObject: {aString: 'abc', aNumber: 123, aArray: [123, 'abc']},
 			someFoo: new Foo(),
 			someFunction: getabc,
-		}
+		},
 	}).$mount(document.createElement('div'))
 	vm.$nextTick(() => {
 		expect(vm.$el.innerHTML).toMatchSnapshot()
@@ -57,7 +57,7 @@ it('accepts the intended props', () => new Promise((resolve, reject) => {
 }))
 
 it('rejects props with wrong types', () => {
-	const mockConsoleError = jest.fn();
+	const mockConsoleError = jest.fn()
 	console.error = mockConsoleError
 	new (Vue.extend((<any>JustProps).vueComponentOptions))({
 		propsData: {
@@ -67,7 +67,7 @@ it('rejects props with wrong types', () => {
 			someObject: [123, 'abc'],
 			someFoo: getabc,
 			someFunction: new Foo(),
-		}
+		},
 	}).$mount(document.createElement('div'))
 	expect(mockConsoleError.mock.calls).toMatchSnapshot()
 })

--- a/test/some-props.spec.ts
+++ b/test/some-props.spec.ts
@@ -14,14 +14,14 @@ function getabc() {
 	return 'abc'
 }
 
-@vts.component()
+@vts.component
 class JustProps extends Vue {
-	@vts.prop() someString = 'abc'
-	@vts.prop() someNumber = 123
-	@vts.prop() someArray = [123, 'abc']
-	@vts.prop() someObject = {aString: 'abc', aNumber: 123, aArray: [123, 'abc']}
-	@vts.prop() someFoo = new Foo()
-	@vts.prop() someFunction = getabc
+	@vts.prop someString = 'abc'
+	@vts.prop someNumber = 123
+	@vts.prop someArray = [123, 'abc']
+	@vts.prop someObject = {aString: 'abc', aNumber: 123, aArray: [123, 'abc']}
+	@vts.prop someFoo = new Foo()
+	@vts.prop someFunction = getabc
 
 	render(createElement: typeof Vue.prototype.$createElement) {
 		return createElement('div', JSON.stringify({


### PR DESCRIPTION
I think this makes components look cleaner. Now it looks like this:

```typescript
import Vue = require('vue')
import { Component, prop, watch, injected } from 'vue-typescript-component'

@Component
export default class Example extends Vue {
    @prop aStringPropWithValue = 'abc'
    @prop aNumberPropWithValue = 123

    @prop aStringProp: string
    @prop aNumberProp: number

    @watch('aString') aStringWatch(val: string, oldVal: string) { /* ... */ }

    @injected errors: any
}
```